### PR TITLE
Add CMake build system as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CMakeConfigScripts"]
+	path = cmake
+	url = https://github.com/Amber-MD/CMakeConfigScripts.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,36 @@
 #AMBER buildfile for cphstats
-project(cphstats CXX Fortran)
+
+cmake_minimum_required(VERSION 3.1)
+project(cphstats NONE)
+
+set(cphstats_MAJOR_VERSION 1)
+set(cphstats_MINOR_VERSION 5)
+set(cphstats_TWEAK_VERSION 0)
+
+set(cphstats_VERSION "${cphstats_MAJOR_VERSION}.${cphstats_MINOR_VERSION}.${cphstats_TWEAK_VERSION}")
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+if(NOT INSIDE_AMBER)
+	include(cmake/AmberBuildSystemInit.cmake)
+	enable_language(CXX Fortran)
+	include(AmberBuildSystem2ndInit)
+	
+	include(CompilerFlags)
+	
+	set(NEEDED_3RDPARTY_TOOLS zlib)
+	set(LINAG_LIBRARIES_REQUIRED FALSE)
+	set(REQUIRED_3RDPARTY_TOOLS "")
+	include(3rdPartyTools)
+	
+	set(PACKAGE_NAME cphstats)
+	set(PACKAGE_FILENAME cphstats)
+	set(BUNDLE_IDENTIFIER org.ambermd.cphstats)
+	set(BUNDLE_SIGNATURE CPHS)
+	include(Packaging)
+endif()
+
+#---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 set(CPHSTATS_CXX_SOURCES main.cpp cpin.cpp
 	string_manip.cpp cloptions.cpp test.cpp cpout.cpp 
@@ -9,15 +40,16 @@ set(CPHSTATS_FORTRAN_SOURCES parse_cpin.F90)
 #---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 #cphstats uses optimization
-set_property(SOURCE ${CPHSTATS_CXX_SOURCES} PROPERTY COMPILE_OPTIONS ${OPT_CXXFLAGS})
-set_property(SOURCE ${CPHSTATS_FORTRAN_SOURCES} PROPERTY COMPILE_OPTIONS ${OPT_FFLAGS})
+message("OPT_CXXFLAGS_SPC: ${OPT_CXXFLAGS_SPC}")
+set_property(SOURCE ${CPHSTATS_CXX_SOURCES} PROPERTY COMPILE_FLAGS ${OPT_CXXFLAGS_SPC})
+set_property(SOURCE ${CPHSTATS_FORTRAN_SOURCES} PROPERTY COMPILE_FLAGS ${OPT_FFLAGS_SPC})
 
 add_executable(cphstats ${CPHSTATS_FORTRAN_SOURCES} ${CPHSTATS_CXX_SOURCES})
 add_executable(cestats ${CPHSTATS_FORTRAN_SOURCES} ${CPHSTATS_CXX_SOURCES})
 
 # cphstats and cestats are built from the same source, but with different defines
 target_compile_definitions(cphstats PUBLIC PH)
-target_compile_definitions(cphstats PUBLIC REDOX)
+target_compile_definitions(cestats PUBLIC REDOX)
 
 
 if(zlib_ENABLED)
@@ -26,3 +58,7 @@ if(zlib_ENABLED)
 endif()
 
 install(TARGETS cphstats cestats DESTINATION ${BINDIR})
+
+if(NOT INSIDE_AMBER)
+	print_build_report()
+endif()


### PR DESCRIPTION
This PR adds the Amber CMake build system as a submodule, with full build and packaging support.

It also fixes a couple errors I made in my first PR with CMakeLists.txt.

To package using CMake, go to your build directory and run 
```
cmake -DPACKAGE_TYPE=<NSIS or DEB or RPM or Bundle> -DPRINT_PACKAGING_REPORT=TRUE .
```
and then
```
make package
```
All of the relevant options from [the options list on the wiki](http://ambermd.org/pmwiki/pmwiki.php/Main/CMake-Common-Options)