### PR TITLE
uninstall target needs to remove config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install: $(PROGNAME) $(PROGNAME2)
 uninstall:
 	/bin/rm -f $(BASEDIR)/bin/$(PROGNAME)
 	/bin/rm -f $(BASEDIR)/bin/$(PROGNAME2)
+	/bin/rm -f config.h
 
 .SUFFIXES: .F90 .cpp .ph.o .redox.o
 


### PR DESCRIPTION
Inside AmberTools, "make uninstall" leaves behind a config.h file, which can mess up compiling
with shadow directories and (I think) with CMake.

I don't think this will hurt the non-AmberTools (standalone) version, since config.h gets created
by "./configure" in that case.