### PR TITLE
Refactoring and improvements

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -1,5 +1,5 @@
 #ifndef CONSTANTS_H
-#define CONSTANTS_H /* These match the constants from sander.h */
+#define CONSTANTS_H /* These match the constants from sander */
 
 #define STATEINF_FLD_C 5
 #define TITR_RES_C 50

--- a/constants.h
+++ b/constants.h
@@ -1,7 +1,6 @@
 #ifndef CONSTANTS_H
-#define CONSTANTS_H
+#define CONSTANTS_H /* These match the constants from sander.h */
 
-// These match the same from sander
 #define STATEINF_FLD_C 5
 #define TITR_RES_C 50
 #define TITR_STATES_C 200
@@ -10,5 +9,8 @@
 
 #define FN_LEN 256
 #define LINEBUF 512
+
+#define KB 0.001987204118
+#define FARADAY 23.06054801
 
 #endif /* CONSTANTS_H */

--- a/depends
+++ b/depends
@@ -1,18 +1,19 @@
-main.cpp: cpin.h cpout.h cloptions.h prottraj.h test.h types.h utilities.h
-utilities.h: cpout.h types.h
-cpout.h: constants.h
-prottraj.h: conprob.h cpin.h cpout.h types.h
-test.cpp: constants.h test.h
-cpin.h: constants.h
-cpout.cpp: cpout.h exceptions.h string_manip.h
-conprob.cpp: conprob.h string_manip.h
-utilities.cpp: utilities.h
-cloptions.cpp: cloptions.h string_manip.h utilities.h
-string_manip.h: exceptions.h
-conprob.h: cpin.h types.h
 cloptions.h: conprob.h exceptions.h
-test.h: cloptions.h cpout.h
-prottraj.cpp: constants.h exceptions.h prottraj.h
+cpin.h: constants.h
+utilities.h: cpout.h types.h
+cloptions.cpp: cloptions.h string_manip.h utilities.h
+conprob.h: cpin.h types.h
 cpin.cpp: constants.h cpin.h exceptions.h string_manip.h
+main.cpp: cpin.h cpout.h cloptions.h prottraj.h test.h types.h utilities.h
+test.cpp: constants.h test.h
+utilities.cpp: exceptions.h utilities.h
+parse_cpin.F90: constants.h
+string_manip.h: exceptions.h
+prottraj.cpp: constants.h exceptions.h prottraj.h
 types.h: cpout.h
+conprob.cpp: conprob.h string_manip.h
 string_manip.cpp: constants.h exceptions.h string_manip.h
+cpout.cpp: cpout.h exceptions.h string_manip.h
+test.h: cloptions.h cpout.h
+prottraj.h: conprob.h cpin.h cpout.h types.h
+cpout.h: constants.h

--- a/parse_cpin.F90
+++ b/parse_cpin.F90
@@ -1,10 +1,5 @@
 
-#define STATEINF_FLD_C 5
-#define TITR_RES_C 50
-#define TITR_STATES_C 200
-#define ATOM_CHRG_C 1000
-#define MAX_H_COUNT 4
-#define FN_LEN 256
+#include "constants.h"
 
 #ifdef REDOX
 subroutine parse_cein(trescnt, eleccnt, stateinf, resname, cein_name, ierr)

--- a/prottraj.cpp
+++ b/prottraj.cpp
@@ -22,9 +22,6 @@ using namespace std;
 
 #ifdef REDOX
 ProtTraj::ProtTraj(Cpin* cpin, float pH, Record const& recin, const float temp0) :
-temp0_(temp0),
-KB_(0.001987204118),
-FARADAY_(23.06054801),
 #else
 ProtTraj::ProtTraj(Cpin* cpin, float pH, Record const& recin) :
 #endif
@@ -32,6 +29,9 @@ cpin_(NULL),
 nres_(0),
 pH_(0.0f),
 nframes_(0),
+#ifdef REDOX
+temp0_(temp0),
+#endif
 time_step_(0)
 {
    cpin_ = cpin;
@@ -112,7 +112,7 @@ void ProtTraj::PrintCalcpka(ostream& fd, const int start) {
    int i = 0;
    for (Cpin::ResIterator rit = cpin_->begin(); rit != cpin_->end(); rit++) {
 #ifdef REDOX
-      double pKa = pH_ - (KB_*temp0_/(FARADAY_*rit->getvNernst()))*log( (double) (nframes_-nprot[i]) / (double) nprot[i] );
+      double pKa = pH_ - (KB*temp0_/(FARADAY*rit->getvNernst()))*log( (double) (nframes_-nprot[i]) / (double) nprot[i] );
       float offset = (float) pKa - pH_;
       fd << setw(3) << rit->getResname() << " " << setw(4) << left << rit->getResnum()
          << ": Offset " << right << setw(7) << offset << " V  Pred Eo " << setw(7) << pKa
@@ -188,7 +188,7 @@ void ProtTraj::PrintChunks(const int window, string const& fname,
         }else if (print_pka) {
             // We want the pKa
 #ifdef REDOX
-            double pKa = pH_ - (KB_*temp0_/(FARADAY_*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
+            double pKa = pH_ - (KB*temp0_/(FARADAY*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
             fp << setprecision(5) << setw(8) << pKa << setprecision(4) << " ";
 #else
             double pKa = pH_ - log10( (1.0 - fracprot) / fracprot );
@@ -213,7 +213,7 @@ void ProtTraj::PrintChunks(const int window, string const& fname,
 /// Prints a cumulative running average time series of the desired property
 void ProtTraj::PrintCumulative(string const& fname, const int interval,
                                const bool print_prot, const bool print_pka) {
-   
+
    // Open up the file and write a header
    ofstream fp(fname.c_str());
    if (!fp.is_open())
@@ -235,7 +235,7 @@ void ProtTraj::PrintCumulative(string const& fname, const int interval,
    long long int totprot = 0ll;
    int c = 0; // simple counter
    for (int i = 1; i < nframes_ + 1; i++) {
-      
+
       { // scope this
       int j = 0;
       for (Cpin::ResIterator rit = cpin_->begin(); rit != cpin_->end(); rit++) {
@@ -259,7 +259,7 @@ void ProtTraj::PrintCumulative(string const& fname, const int interval,
            }else if (print_pka) {
                // We want the pKa
 #ifdef REDOX
-               double pKa = pH_ - (KB_*temp0_/(FARADAY_*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
+               double pKa = pH_ - (KB*temp0_/(FARADAY*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
                fp << setprecision(5) << setw(8) << pKa << setprecision(4) << " ";
 #else
                double pKa = pH_ - log10( (1.0 - fracprot) / fracprot );
@@ -329,7 +329,7 @@ void ProtTraj::PrintRunningAvg(const int window, const int interval,
         }else if (print_pka) {
             // We want the pKa
 #ifdef REDOX
-            double pKa = pH_ - (KB_*temp0_/(FARADAY_*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
+            double pKa = pH_ - (KB*temp0_/(FARADAY*rit->getvNernst()))*log( (1.0 - fracprot) / fracprot );
             fp << setprecision(5) << setw(8) << pKa << setprecision(4) << " ";
 #else
             double pKa = pH_ - log10( (1.0 - fracprot) / fracprot );

--- a/prottraj.h
+++ b/prottraj.h
@@ -75,19 +75,13 @@ class ProtTraj {
       // Number of frames
       long long int nframes_;
 
-      // Monte carlo time step
-      int time_step_;
-
 #ifdef REDOX
       // Temperature
       float temp0_;
-
-      // Boltzmann constant in kcal/(mol.K)
-      const double KB_;
-
-      // Faraday constant in kcal/(mol.V)
-      const double FARADAY_;
 #endif
+
+      // Monte carlo time step
+      int time_step_;
 
       typedef struct {
          std::vector<long long int> state_cnt;


### PR DESCRIPTION
* Move physical constants to constants.h
* Fix compiler warnings due to reordered imports
* Remove duplicate constants by including constants.h in the cpin parser
  directly