### PR TITLE
Removed the flag -temp0 from cestats

### DIFF
--- a/cloptions.cpp
+++ b/cloptions.cpp
@@ -21,9 +21,6 @@ overwrite_(false),
 interval_(1000),
 protonated_(true),
 time_step_(0.002f),
-#ifdef REDOX
-temp0_(300.0f),
-#endif
 pKa_(false),
 debug_(false),
 expert_(false)
@@ -123,13 +120,6 @@ expert_(false)
          marked[i++] = true;
          marked[i] = true;
          time_step_ = StringToFloat(argnext);
-#ifdef REDOX
-     }else if (arg == "-temp0" || arg == "--temperature") {
-         if (!has_another) {parse_return_ = INSUFARGS; break;}
-         marked[i++] = true;
-         marked[i] = true;
-         temp0_ = StringToFloat(argnext);
-#endif
      }else if (arg == "--chunk") {
          if (!has_another) {parse_return_ = INSUFARGS; break;}
          marked[i++] = true;
@@ -249,12 +239,6 @@ void CLOptions::Help() {
    cout << "                   Input cpin file (from pmemd or sander) with titrating residue" << endl;
 #endif
    cout << "                   information." << endl;
-#ifdef REDOX
-   cout << "    -temp0 FLOAT, --temperature FLOAT" << endl;
-   cout << "                   This is the temperature in Kelvins you used in your simulations." << endl;
-   cout << "                   It will be used to compute Eo using the Nernst equation." << endl;
-   cout << "                   Default is 300.0 K" << endl;
-#endif
    cout << "    -t FLOAT, --time-step FLOAT" << endl;
    cout << "                   This is the time step in ps you used in your simulations." << endl;
    cout << "                   It will be used to print data as a function of time." << endl;
@@ -401,7 +385,7 @@ void CLOptions::Help() {
 
 void CLOptions::Usage() {
 #ifdef REDOX
-   cout << "Usage: " << prog_ << " [-O] [-V] [-h] [-i <cein>] [-t] [-o FILE] [-temp0 FLOAT] [-R FILE -r INT]" << endl;
+   cout << "Usage: " << prog_ << " [-O] [-V] [-h] [-i <cein>] [-t] [-o FILE] [-R FILE -r INT]" << endl;
    cout << "             [--chunk INT --chunk-out FILE] [--cumulative --cumulative-out FILE]" << endl;
    cout << "             [-v INT] [-n INT] [-p|-d] [--calceo|--no-calceo] [--fix-remd]" << endl;
    cout << "             [--population FILE] [-c CONDITION -c CONDITION -c ...]" << endl;
@@ -454,13 +438,6 @@ int CLOptions::CheckInput() {
       cerr << "Error: --time-step must be a positive number!" << endl;
       inerr = 1;
    }
-
-#ifdef REDOX
-   if (temp0_ <= 0) {
-      cerr << "Error: --temperature must be a positive number!" << endl;
-      inerr = 1;
-   }
-#endif
 
    if (interval_ <= 0) {
       cerr << "Error: -n/--interval must be a positive integer!" << endl;

--- a/cloptions.h
+++ b/cloptions.h
@@ -50,9 +50,6 @@ class CLOptions {
       bool PrintDeprotonated() const           { return !protonated_;    }
       std::string REMDPrefix() const           { return reorder_prefix_; }
       float TimeStep() const                   { return time_step_;      }
-#ifdef REDOX
-      float Temperature() const                { return temp0_;          }
-#endif
       bool pKa() const                         { return pKa_;            }
       std::string Population() const           { return population_;     }
       std::vector<ConditionalProb> CondProbs() { return condprobs_;      }
@@ -107,10 +104,6 @@ class CLOptions {
       bool protonated_;
       /// Time step used in the simulation
       float time_step_;
-#ifdef REDOX
-      /// Temperature used in the simulation
-      float temp0_;
-#endif
       /// Do we put predicted pKas for time series?
       bool pKa_;
       /// Protonated fraction output file

--- a/cpout.cpp
+++ b/cpout.cpp
@@ -16,6 +16,9 @@ type_(ASCII),
 valid_(true),
 done_(false),
 orig_ph_(0.0f),
+#ifdef REDOX
+orig_temp0_(0.0f),
+#endif
 step_size_(0),
 nres_(0),
 remd_file_(false)
@@ -61,7 +64,7 @@ remd_file_(false)
       valid_ = false;
   }else if (valid_) {
 #ifdef REDOX
-      if (sscanf(buf, "Redox potential: %f V\n", &orig_ph_) == 1) {
+      if (sscanf(buf, "Redox potential: %f V Temperature: %f K\n", &orig_ph_, &orig_temp0_) == 2) {
 #else
       if (sscanf(buf, "Solvent pH: %f\n", &orig_ph_) == 1) {
 #endif
@@ -150,17 +153,23 @@ Record CpoutFile::GetRecord() {
    }
    Record result;
    float pH;
+#ifdef REDOX
+   float temp0;
+#endif
    int res;
    int state;
    result.pH = 0.0f;
    result.full = false;
 #ifdef REDOX
-   if (sscanf(buf, "Redox potential: %f V\n", &pH) == 1) {
+   if (sscanf(buf, "Redox potential: %f V Temperature: %f K\n", &pH, &temp0) == 2) {
 #else
    if (sscanf(buf, "Solvent pH: %f\n", &pH) == 1) {
 #endif
       result.full = true;
       result.pH = pH;
+#ifdef REDOX
+      result.Temperature = temp0;
+#endif
       Gets(buf, LINEBUF); // Monte Carlo step size
       Gets(buf, LINEBUF); // Time step:
       sscanf(buf, "Time step: %d\n", &result.time_step);

--- a/cpout.h
+++ b/cpout.h
@@ -24,6 +24,9 @@ typedef struct {
    int time_step;
    float time;
    float pH;
+#ifdef REDOX
+   float Temperature;
+#endif
    bool full;
 } Record;
 
@@ -41,6 +44,9 @@ class CpoutFile {
       int Nres() const       { return nres_;            }
       int StepSize() const   { return step_size_;       }
       float pH() const       { return orig_ph_;         }
+#ifdef REDOX
+      float Temperature() const { return orig_temp0_;      }
+#endif
       float startTime() const{ return start_time_;      }
       void WarnRemd() const {
             if (remd_file_)
@@ -98,6 +104,9 @@ class CpoutFile {
       bool valid_;       // Is this a valid file?
       bool done_;        // Is this file done reading?
       float orig_ph_;    // pH on the opening full record
+#ifdef REDOX
+      float orig_temp0_;    // Temperature on the opening full record
+#endif
       int step_size_;    // Monte carlo step size
       int nres_;         // Number of residues defined in this cpout
       float start_time_; // The time in the first full record

--- a/main.cpp
+++ b/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char**argv) {
       return sort_remd_files(cpouts, clopt.REMDPrefix(), clopt.Overwrite());
 
 #ifdef REDOX
-   ProtTraj stats = ProtTraj(&my_cpin, cpouts[0].pH(), cpouts[0].GetRecord(), clopt.Temperature());
+   ProtTraj stats = ProtTraj(&my_cpin, cpouts[0].pH(), cpouts[0].GetRecord(), cpouts[0].Temperature());
 #else
    ProtTraj stats = ProtTraj(&my_cpin, cpouts[0].pH(), cpouts[0].GetRecord());
 #endif

--- a/prottraj.cpp
+++ b/prottraj.cpp
@@ -21,7 +21,7 @@
 using namespace std;
 
 #ifdef REDOX
-ProtTraj::ProtTraj(Cpin* cpin, float pH, Record const& recin, const float temp0) :
+ProtTraj::ProtTraj(Cpin* cpin, float pH, Record const& recin, float temp0) :
 #else
 ProtTraj::ProtTraj(Cpin* cpin, float pH, Record const& recin) :
 #endif
@@ -30,14 +30,17 @@ nres_(0),
 pH_(0.0f),
 nframes_(0),
 #ifdef REDOX
-temp0_(temp0),
+temp0_(0.0f),
 #endif
 time_step_(0)
 {
    cpin_ = cpin;
    nres_ = cpin->getTrescnt();
    pH_ = pH;
-
+#ifdef REDOX
+   temp0_ = temp0;
+#endif
+   
    // Set the first point
    for (int i = 0; i < nres_; i++)
       last_point_.push_back(0);

--- a/test_redox/E0.75/lys-iron.md2.ceout
+++ b/test_redox/E0.75/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.75/lys-iron.md3.ceout
+++ b/test_redox/E0.75/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.75/lys-iron.md4.ceout
+++ b/test_redox/E0.75/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.75/lys-iron.md5.ceout
+++ b/test_redox/E0.75/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.78/lys-iron.md2.ceout
+++ b/test_redox/E0.78/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.78/lys-iron.md3.ceout
+++ b/test_redox/E0.78/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.78/lys-iron.md4.ceout
+++ b/test_redox/E0.78/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.78/lys-iron.md5.ceout
+++ b/test_redox/E0.78/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.81/lys-iron.md2.ceout
+++ b/test_redox/E0.81/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.81/lys-iron.md3.ceout
+++ b/test_redox/E0.81/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.81/lys-iron.md4.ceout
+++ b/test_redox/E0.81/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.81/lys-iron.md5.ceout
+++ b/test_redox/E0.81/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.84/lys-iron.md2.ceout
+++ b/test_redox/E0.84/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.84/lys-iron.md3.ceout
+++ b/test_redox/E0.84/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.84/lys-iron.md4.ceout
+++ b/test_redox/E0.84/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.84/lys-iron.md5.ceout
+++ b/test_redox/E0.84/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.87/lys-iron.md2.ceout
+++ b/test_redox/E0.87/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.87/lys-iron.md3.ceout
+++ b/test_redox/E0.87/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.87/lys-iron.md4.ceout
+++ b/test_redox/E0.87/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  1 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.87/lys-iron.md5.ceout
+++ b/test_redox/E0.87/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.90/lys-iron.md2.ceout
+++ b/test_redox/E0.90/lys-iron.md2.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.90/lys-iron.md3.ceout
+++ b/test_redox/E0.90/lys-iron.md3.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0 E:    0.8700000 V
 
 Residue    0 State:  1 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  0 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.90/lys-iron.md4.ceout
+++ b/test_redox/E0.90/lys-iron.md4.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  0 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1 E:    0.8400000 V
 
 Residue    0 State:  0 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/E0.90/lys-iron.md5.ceout
+++ b/test_redox/E0.90/lys-iron.md5.ceout
@@ -1,4 +1,4 @@
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1 E:    0.8700000 V
 
 Residue    0 State:  0 E:    0.8700000 V
 
-Redox potential:    0.8700000 V
+Redox potential:    0.8700000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  0 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0 E:    0.8400000 V
 
 Residue    0 State:  1 E:    0.8400000 V
 
-Redox potential:    0.8400000 V
+Redox potential:    0.8400000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1 E:    0.7500000 V
 
 Residue    0 State:  1 E:    0.7500000 V
 
-Redox potential:    0.7500000 V
+Redox potential:    0.7500000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1 E:    0.8100000 V
 
 Residue    0 State:  1 E:    0.8100000 V
 
-Redox potential:    0.8100000 V
+Redox potential:    0.8100000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1 E:    0.7800000 V
 
 Residue    0 State:  1 E:    0.7800000 V
 
-Redox potential:    0.7800000 V
+Redox potential:    0.7800000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0 E:    0.9000000 V
 
 Residue    0 State:  0 E:    0.9000000 V
 
-Redox potential:    0.9000000 V
+Redox potential:    0.9000000 V Temperature: 300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/md2_ceout.E_0.75000.save
+++ b/test_redox/md2_ceout.E_0.75000.save
@@ -1,4 +1,4 @@
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.75000
+Redox potential:    0.7500000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/md3_ceout.E_0.81000.save
+++ b/test_redox/md3_ceout.E_0.81000.save
@@ -1,4 +1,4 @@
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.81000
+Redox potential:    0.8100000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/md4_ceout.E_0.84000.save
+++ b/test_redox/md4_ceout.E_0.84000.save
@@ -1,4 +1,4 @@
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1
 
 Residue    0 State:  1
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.84000
+Redox potential:    0.8400000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/test_redox/md5_ceout.E_0.90000.save
+++ b/test_redox/md5_ceout.E_0.90000.save
@@ -1,4 +1,4 @@
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:        5
 Time:   2000.008
@@ -400,7 +400,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     1000
 Time:   2001.998
@@ -804,7 +804,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     2000
 Time:   2003.998
@@ -1208,7 +1208,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     3000
 Time:   2005.998
@@ -1612,7 +1612,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     4000
 Time:   2007.998
@@ -2016,7 +2016,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     5000
 Time:   2009.998
@@ -2420,7 +2420,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     6000
 Time:   2011.998
@@ -2824,7 +2824,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     7000
 Time:   2013.998
@@ -3228,7 +3228,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     8000
 Time:   2015.998
@@ -3632,7 +3632,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:     9000
 Time:   2017.998
@@ -4036,7 +4036,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    10000
 Time:   2019.998
@@ -4440,7 +4440,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    11000
 Time:   2021.998
@@ -4844,7 +4844,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    12000
 Time:   2023.998
@@ -5248,7 +5248,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    13000
 Time:   2025.998
@@ -5652,7 +5652,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    14000
 Time:   2027.998
@@ -6056,7 +6056,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    15000
 Time:   2029.998
@@ -6460,7 +6460,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    16000
 Time:   2031.998
@@ -6864,7 +6864,7 @@ Residue    0 State:  0
 
 Residue    0 State:  1
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    17000
 Time:   2033.998
@@ -7268,7 +7268,7 @@ Residue    0 State:  1
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    18000
 Time:   2035.998
@@ -7672,7 +7672,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    19000
 Time:   2037.998
@@ -8076,7 +8076,7 @@ Residue    0 State:  0
 
 Residue    0 State:  0
 
-Redox potential:  0.90000
+Redox potential:    0.9000000 V Temperature:  300.00 K
 Monte Carlo step size:        5
 Time step:    20000
 Time:   2039.998

--- a/utilities.cpp
+++ b/utilities.cpp
@@ -90,7 +90,7 @@ int sort_remd_files(CpoutList cpouts, string const& prefix,
          }
          if (rec.full) {
 #ifdef REDOX
-            fprintf(filemap[rec.pH], "Redox potential: %8.5f\n", rec.pH);
+            fprintf(filemap[rec.pH], "Redox potential: %12.7f V Temperature: %7.2f K\n", rec.pH, rec.Temperature);
 #else
             fprintf(filemap[rec.pH], "Solvent pH: %8.5f\n", rec.pH);
 #endif


### PR DESCRIPTION
Now the temperature is read from CEOUT, at the same line where the redox potential is read (I recently modified PMEMD and Sander to print the temperature there).