### PR TITLE
Fixes #20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ $(PROGNAME2): $(OBJS2)
 	$(CXX) -o $(PROGNAME2) $(OBJS2) $(LDFLAGS) $(NOFORTRANMAIN) $(ZLIB) $(BZLIB)
 
 install: $(PROGNAME) $(PROGNAME2)
-	/bin/mv $(PROGNAME) $(BASEDIR)/bin
-	/bin/mv $(PROGNAME2) $(BASEDIR)/bin
+	/bin/mv $(PROGNAME) $(BINDIR)/bin
+	/bin/mv $(PROGNAME2) $(BINDIR)/bin
 
 uninstall:
-	/bin/rm -f $(BASEDIR)/bin/$(PROGNAME)
-	/bin/rm -f $(BASEDIR)/bin/$(PROGNAME2)
+	/bin/rm -f $(BINDIR)/bin/$(PROGNAME)
+	/bin/rm -f $(BINDIR)/bin/$(PROGNAME2)
 	/bin/rm -f config.h
 
 .SUFFIXES: .F90 .cpp .ph.o .redox.o

--- a/configure
+++ b/configure
@@ -43,7 +43,7 @@ elif 'CC' in os.environ:
       sys.stderr.write('Unrecognized C compiler %s' % os.environ['CXX'])
 else:
    sys.stderr.write('No compiler provided or detected from the environment.\n')
-   
+
 if len(arg) > 1:
    sys.stderr.write("Too many command-line arguments found.\n")
    parser.print_help()
@@ -144,6 +144,6 @@ CXXFLAGS = %(cppflags)s
 LDFLAGS = %(ldflags)s
 
 # Where program gets installed
-BASEDIR = %(prefix)s
+BINDIR = %(prefix)s
 """ % confighopts)
 f.close()


### PR DESCRIPTION
In the Makefile, the BASEDIR variable should be changed to BINDIR -
otherwise --prefix installs do not work properly.